### PR TITLE
[refactor/SWM-259] 기존 코드 개선

### DIFF
--- a/src/app/[country]/board/[Id]/page.tsx
+++ b/src/app/[country]/board/[Id]/page.tsx
@@ -127,6 +127,7 @@ const Page = async ({ params }: { params: { id: string } }) => {
             props={{
               userImageUrl: boardDetail.userImageUrl,
               nickName: boardDetail.nickName,
+              userId: boardDetail.userId,
               ageRange: boardDetail.ageRange,
               gender: boardDetail.gender,
               nationality: boardDetail.nationality,

--- a/src/app/[country]/board/[Id]/page.tsx
+++ b/src/app/[country]/board/[Id]/page.tsx
@@ -5,13 +5,9 @@ import * as styles from '@/styles/country/board/id/page.css';
 import TravelerCard from '@/components/country/board/id/TravelerCard';
 import { Language } from '@/components/common/Language';
 import CommentInput from '@/components/common/CommentInput';
-import ChatModal from '@/components/country/board/id/ChatModal';
 import CommentList from '@/components/common/CommentList';
 import { TripTypeButton } from '@/components/common/TripTypeButton';
 import AttributeBox from '@/components/country/board/id/AttributeBox';
-import LoginModal from '@/components/common/LoginModal';
-import useModal from '@/hooks/useModal';
-import { hasAccessToken } from '@/utils/server/token';
 import { BoardDetailType } from '@/types/country/board';
 import { headers } from 'next/headers';
 

--- a/src/components/common/BoardCard.tsx
+++ b/src/components/common/BoardCard.tsx
@@ -17,7 +17,7 @@ const BoardCard = ({ props }: { props: BoardPreviewProps }) => {
   };
 
   return (
-    <div className={styles.postCard} onClick={clickHandler}>
+    <div className={styles.boardCard} onClick={clickHandler}>
       <div className={styles.imageBox}>
         <Image
           src={props.imageUrl}

--- a/src/components/common/CommentInput.tsx
+++ b/src/components/common/CommentInput.tsx
@@ -1,21 +1,20 @@
+'use client';
 import * as styles from '@/styles/components/common/comment-input.css';
 import Profile from './Profile';
 import { postBoardComment } from '@/api/board';
 import { useEffect, useRef, useState } from 'react';
 import { useUserStore } from '@/store/userStore';
+import useModal from '@/hooks/useModal';
+import { useRouter } from 'next/navigation';
+import LoginModal from './LoginModal';
 
-const CommentInput = ({
-  boardId,
-  inputHandler,
-  isOpen,
-  openModal,
-}: {
-  boardId: number;
-  isOpen: boolean;
-  inputHandler: () => void;
-  openModal: () => void;
-}) => {
+// TODO :: isOpen, openModal
+const CommentInput = ({ boardId }: { boardId: number }) => {
   const [content, setContent] = useState<string>('');
+
+  const { isOpen, openModal, closeModal } = useModal();
+
+  const router = useRouter();
 
   const isLoggedIn = useUserStore((state) => state.isLoggedIn);
   const inputRef = useRef<HTMLInputElement | null>(null);
@@ -34,7 +33,7 @@ const CommentInput = ({
   const submitComment = async () => {
     if (content.trim()) {
       await postBoardComment(boardId, content.trim());
-      inputHandler();
+      router.refresh();
     }
     setContent('');
   };
@@ -48,6 +47,7 @@ const CommentInput = ({
 
   return (
     <>
+      <LoginModal isOpen={isOpen} closeModal={closeModal} />
       <div
         className={styles.commentInputProfileContainer}
         onClick={clickHandler}

--- a/src/components/common/CommentInput.tsx
+++ b/src/components/common/CommentInput.tsx
@@ -17,6 +17,7 @@ const CommentInput = ({ boardId }: { boardId: number }) => {
   const router = useRouter();
 
   const isLoggedIn = useUserStore((state) => state.isLoggedIn);
+
   const inputRef = useRef<HTMLInputElement | null>(null);
 
   const changeHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -47,7 +48,11 @@ const CommentInput = ({ boardId }: { boardId: number }) => {
 
   return (
     <>
-      <LoginModal isOpen={isOpen} closeModal={closeModal} />
+      {isLoggedIn ? (
+        <></>
+      ) : (
+        <LoginModal isOpen={isOpen} closeModal={closeModal} />
+      )}
       <div
         className={styles.commentInputProfileContainer}
         onClick={clickHandler}

--- a/src/components/common/Language.tsx
+++ b/src/components/common/Language.tsx
@@ -1,45 +1,29 @@
 import * as styles from '@/styles/components/common/language.css';
 
-const Korean = () => {
-  return (
-    <div className={styles.koreanBox}>
-      <span className={styles.text}>한국어</span>
-    </div>
-  );
-};
-
-const English = () => {
-  return (
-    <div className={styles.englishBox}>
-      <span className={styles.text}>영어</span>
-    </div>
-  );
-};
-
-const Chinese = () => {
-  return (
-    <div className={styles.ChineseBox}>
-      <span className={styles.text}>중국어</span>
-    </div>
-  );
-};
-
-const Japanese = () => {
-  return (
-    <div className={styles.JapaneseBox}>
-      <span className={styles.text}>일본어</span>
-    </div>
-  );
-};
-
 export const Language = ({ language }: { language: string }) => {
   if (language === 'Korean') {
-    return <Korean />;
+    return (
+      <div>
+        <span className={styles.text({ language: 'korean' })}>한국어</span>
+      </div>
+    );
   } else if (language === 'English') {
-    return <English />;
+    return (
+      <div>
+        <span className={styles.text({ language: 'english' })}>영어</span>
+      </div>
+    );
   } else if (language === 'Chinese') {
-    return <Chinese />;
+    return (
+      <div>
+        <span className={styles.text({ language: 'chinese' })}>중국어</span>
+      </div>
+    );
   } else {
-    return <Japanese />;
+    return (
+      <div>
+        <span className={styles.text({ language: 'japanese' })}>일본어</span>
+      </div>
+    );
   }
 };

--- a/src/components/common/LoginModal.tsx
+++ b/src/components/common/LoginModal.tsx
@@ -1,3 +1,4 @@
+'use client';
 import ModalWrapper from './ModalWrapper';
 import { useUserStore } from '@/store/userStore';
 import Image from 'next/image';

--- a/src/components/common/ModalWrapper.tsx
+++ b/src/components/common/ModalWrapper.tsx
@@ -1,6 +1,7 @@
 'use client';
 import * as styles from '@/styles/components/common/modal-wrapper.css';
 import { ReactNode, useEffect } from 'react';
+import { createPortal } from 'react-dom';
 
 type Props = {
   isOpen: boolean;
@@ -18,22 +19,15 @@ const ModalWrapper = ({ isOpen, closeModal, children }: Props) => {
     closeModal();
   };
 
-  useEffect(() => {
-    if (isOpen) {
-      document.body.style.overflow = 'hidden';
-    } else {
-      document.body.style.overflow = 'auto';
-    }
-  }, [isOpen]);
-
   if (!isOpen) return <></>;
 
-  return (
+  return createPortal(
     <div className={styles.background} onClick={backgroundHandler}>
       <div className={styles.modal} onClick={propagationHandler}>
         {children}
       </div>
-    </div>
+    </div>,
+    document.body,
   );
 };
 

--- a/src/components/country/BoardPreview.tsx
+++ b/src/components/country/BoardPreview.tsx
@@ -10,16 +10,19 @@ import { BoardPreviewProps } from '@/types/country/board';
 import { EmptyBoard } from './EmptyBoard';
 import { usePathname } from 'next/navigation';
 import { getCountryName } from '@/utils/country';
+import BoardPreviewSkeleton from './BoardPreviewSkeleton';
 
 const BoardPreview = () => {
   const pathname = usePathname();
   const [country, setCountry] = useState<string>('');
   const [boardPreview, setBoardPreview] = useState<BoardPreviewProps[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
 
   const getBoardPreviewList = async () => {
     if (country) {
       const data = await getBoardPreview(country);
       setBoardPreview(data.data);
+      setIsLoading(false);
     }
   };
 
@@ -41,7 +44,9 @@ const BoardPreview = () => {
         </span>
         <More path="/board" category="" />
       </div>
-      {boardPreview.length ? (
+      {isLoading ? (
+        <BoardPreviewSkeleton />
+      ) : boardPreview.length ? (
         <ul className={styles.boardContainer}>
           {boardPreview.map((board) => (
             <li key={board.boardId}>

--- a/src/components/country/BoardPreviewSkeleton.tsx
+++ b/src/components/country/BoardPreviewSkeleton.tsx
@@ -1,0 +1,40 @@
+import * as styles from '@/styles/components/common/board-card.css';
+import { boardContainer } from '@/styles/country/page.css';
+
+const BoardPreviewSkeleton = () => {
+  return (
+    <div className={boardContainer}>
+      {[...Array(4)].map((_, index) => (
+        <div className={styles.containerSkeleton}>
+          <div className={`${styles.imageBox}`}>
+            <div className={`${styles.image} ${styles.skeleton}`}></div>
+          </div>
+          <div className={`${styles.contentContainer}`}>
+            <div
+              className={`${styles.languageSkeleton} ${styles.skeleton}`}
+            ></div>
+            <span className={`${styles.title} ${styles.skeleton}`}></span>
+            <div className={`${styles.infoContainer} ${styles.skeleton}`}>
+              -
+            </div>
+            <div className={`${styles.infoContainer} ${styles.skeleton}`}>
+              -
+            </div>
+            <div className={`${styles.profileContainer}`}>
+              <div
+                className={`${styles.profileSkeleton} ${styles.skeleton}`}
+              ></div>
+              <span
+                className={`${styles.profileInfoSkeleton} ${styles.skeleton}`}
+              >
+                f
+              </span>
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default BoardPreviewSkeleton;

--- a/src/components/country/MoveToMain.tsx
+++ b/src/components/country/MoveToMain.tsx
@@ -1,12 +1,15 @@
 'use client';
+import { useCountryStore } from '@/store/countryStore';
 import { countryText, moveToMain } from '@/styles/country/page.css';
 import { CountryInfo } from '@/types/main/country';
 import { useRouter } from 'next/navigation';
 
 const MoveToMain = ({ props }: { props: CountryInfo }) => {
   const router = useRouter();
+  const { initialize, setContinent } = useCountryStore();
 
   const continentClickHandler = () => {
+    setContinent(props.continentEnglishName, props.continentName);
     router.push('/');
   };
 
@@ -15,6 +18,7 @@ const MoveToMain = ({ props }: { props: CountryInfo }) => {
   };
 
   const homeClickHandler = () => {
+    initialize();
     router.push('/');
   };
 

--- a/src/components/country/board/id/ChatButton.tsx
+++ b/src/components/country/board/id/ChatButton.tsx
@@ -1,7 +1,10 @@
+'use client';
+import useModal from '@/hooks/useModal';
 import * as styles from '@/styles/country/board/id/chat-button.css';
 import Image from 'next/image';
 
-const ChatButton = ({ openModal }: { openModal: () => void }) => {
+const ChatButton = () => {
+  const { isOpen, openModal, closeModal } = useModal();
   return (
     <button className={styles.buttonContainer} onClick={openModal}>
       <Image

--- a/src/components/country/board/id/ChatButton.tsx
+++ b/src/components/country/board/id/ChatButton.tsx
@@ -1,21 +1,43 @@
 'use client';
 import useModal from '@/hooks/useModal';
+import { useUserStore } from '@/store/userStore';
 import * as styles from '@/styles/country/board/id/chat-button.css';
 import Image from 'next/image';
+import ChatModal from './ChatModal';
+import LoginModal from '@/components/common/LoginModal';
 
-const ChatButton = () => {
+const ChatButton = ({
+  nickName,
+  userId,
+}: {
+  nickName: string;
+  userId: number;
+}) => {
   const { isOpen, openModal, closeModal } = useModal();
+  const { isLoggedIn } = useUserStore();
   return (
-    <button className={styles.buttonContainer} onClick={openModal}>
-      <Image
-        className={styles.icon}
-        src="/icons/send.svg"
-        alt="sendChat"
-        width={15}
-        height={15}
-      />
-      동행 요청
-    </button>
+    <>
+      {isLoggedIn ? (
+        <ChatModal
+          nickName={nickName}
+          userId={userId}
+          isOpen={isOpen}
+          closeModal={closeModal}
+        />
+      ) : (
+        <LoginModal isOpen={isOpen} closeModal={closeModal} />
+      )}
+      <button className={styles.buttonContainer} onClick={openModal}>
+        <Image
+          className={styles.icon}
+          src="/icons/send.svg"
+          alt="sendChat"
+          width={15}
+          height={15}
+        />
+        동행 요청
+      </button>
+    </>
   );
 };
 

--- a/src/components/country/board/id/TravelerCard.tsx
+++ b/src/components/country/board/id/TravelerCard.tsx
@@ -6,6 +6,7 @@ import ChatButton from './ChatButton';
 type Props = {
   userImageUrl: string;
   nickName: string;
+  userId: number;
   ageRange: string;
   gender: string;
   nationality: string;
@@ -52,7 +53,7 @@ const TravelerCard = ({ props }: { props: Props }) => {
         <span className={styles.infoTitle}>동행 평점</span>
         <span className={styles.infoContent}>별 네개</span>
       </div>
-      <ChatButton />
+      <ChatButton nickName={props.nickName} userId={props.userId} />
     </div>
   );
 };

--- a/src/components/country/board/id/TravelerCard.tsx
+++ b/src/components/country/board/id/TravelerCard.tsx
@@ -12,13 +12,9 @@ type Props = {
   selfIntroduction: string;
 };
 
-const TravelerCard = ({
-  props,
-  openModal,
-}: {
-  props: Props;
-  openModal: () => void;
-}) => {
+// TODO: // OpenModal props
+
+const TravelerCard = ({ props }: { props: Props }) => {
   return (
     <div className={styles.cardContainer}>
       <div className={styles.travelerTitle}>
@@ -56,7 +52,7 @@ const TravelerCard = ({
         <span className={styles.infoTitle}>동행 평점</span>
         <span className={styles.infoContent}>별 네개</span>
       </div>
-      <ChatButton openModal={openModal} />
+      <ChatButton />
     </div>
   );
 };

--- a/src/components/country/post/PostCardList.tsx
+++ b/src/components/country/post/PostCardList.tsx
@@ -6,7 +6,6 @@ import { useEffect, useState } from 'react';
 import SelectCateogry from './SelectCategory';
 import { PostPreviewProps } from '@/types/country/post';
 import { getPostList } from '@/api/post';
-import { useCountryStore } from '@/store/countryStore';
 import { usePostStore } from '@/store/postStore';
 import EmptyPost from '../EmptyPost';
 import { usePathname } from 'next/navigation';

--- a/src/components/header/HeaderLogo.tsx
+++ b/src/components/header/HeaderLogo.tsx
@@ -1,3 +1,4 @@
+import { useCountryStore } from '@/store/countryStore';
 import {
   logo,
   logoContainer,
@@ -8,7 +9,10 @@ import { useRouter } from 'next/navigation';
 
 const HeaderLogo = ({ color = 'b_' }: { color?: string }) => {
   const router = useRouter();
+
+  const { initialize } = useCountryStore();
   const clickHandler = () => {
+    initialize();
     router.push('/');
   };
 
@@ -28,7 +32,6 @@ const HeaderLogo = ({ color = 'b_' }: { color?: string }) => {
         height={20}
         alt="title"
       />
-      {/* <div className={title2({ theme: 'clear' })}>TripMingle</div> */}
     </div>
   );
 };

--- a/src/components/main/CountryList.tsx
+++ b/src/components/main/CountryList.tsx
@@ -1,5 +1,4 @@
 import { countryContainer } from '@/styles/main/country.css';
-import { CountryType } from '@/types/main/country';
 import CountryListItem from './CountryListItem';
 import { useCountryStore } from '@/store/countryStore';
 

--- a/src/components/main/CountrySearch.tsx
+++ b/src/components/main/CountrySearch.tsx
@@ -16,8 +16,9 @@ const CountrySearch = () => {
   const clickHandler = async () => {
     if (keyword) {
       const data = await getCountryByKeyword(keyword);
-      setCountries(data.data);
       setContinent('', '');
+      setCountries(data.data);
+      setKeyword('');
     }
   };
 

--- a/src/components/main/CountrySelect.tsx
+++ b/src/components/main/CountrySelect.tsx
@@ -8,10 +8,17 @@ import { getCountryByContinent } from '@/api/country';
 import ContinentList from './ContinentList';
 import CountryList from './CountryList';
 import { useCountryStore } from '@/store/countryStore';
+import { useEffect } from 'react';
 
 const CountrySelect = () => {
-  const { countries, continent, continentKor, setCountries, setContinent } =
-    useCountryStore();
+  const {
+    countries,
+    continent,
+    continentKor,
+    setCountries,
+    setContinent,
+    initialize,
+  } = useCountryStore();
 
   const continentClick = async (continent: string, continentKor: string) => {
     const data = await getCountryByContinent(continent);
@@ -19,22 +26,33 @@ const CountrySelect = () => {
     setContinent(continent, continentKor);
   };
 
+  useEffect(() => {
+    const getCountries = async () => {
+      const data = await getCountryByContinent(continent);
+      setCountries(data.data);
+    };
+
+    if (continent) {
+      getCountries();
+    }
+
+    return () => {
+      initialize();
+    };
+  }, [continent]);
+
   if (continent === '' && countries.length == 0) {
+    // 첫 화면일땐 대륙
     return (
       <div className={selectContainer}>
         <ContinentList clickHandler={continentClick} />
       </div>
     );
   } else {
+    // 검색하거나 클릭하면 나라 리스트
     return (
       <div className={selectContainer}>
-        <div
-          className={moveToContinent}
-          onClick={() => {
-            setContinent('', '');
-            setCountries([]);
-          }}
-        >
+        <div className={moveToContinent} onClick={initialize}>
           <span className={moveToContinent}>{'홈 > '}</span>
           <span className={continentText}>{continentKor}</span>
         </div>

--- a/src/hooks/useModal.ts
+++ b/src/hooks/useModal.ts
@@ -1,3 +1,4 @@
+'use client';
 import { useState } from 'react';
 
 type UseModalReturn = {

--- a/src/store/countryStore.ts
+++ b/src/store/countryStore.ts
@@ -7,6 +7,7 @@ interface CountryState {
   continentKor: string;
   setContinent: (continent: string, continentKor: string) => void;
   setCountries: (countries: CountryType[]) => void;
+  initialize: () => void;
 }
 
 export const useCountryStore = create<CountryState>((set) => ({
@@ -15,4 +16,10 @@ export const useCountryStore = create<CountryState>((set) => ({
   continentKor: '',
   setContinent: (continent, continentKor) => set({ continent, continentKor }),
   setCountries: (countries) => set({ countries }),
+  initialize: () =>
+    set({
+      countries: [],
+      continent: '',
+      continentKor: '',
+    }),
 }));

--- a/src/styles/components/common/board-card.css.ts
+++ b/src/styles/components/common/board-card.css.ts
@@ -1,16 +1,20 @@
 import { vars } from '@/styles/globalTheme.css';
 import { style } from '@vanilla-extract/css';
 
-export const postCard = style({
+export const boardCard = style({
   display: 'block',
   width: '100%',
-  maxWidth: 255,
-  height: 'auto', // 비율 유지를 위해 auto로 변경
+  minWidth: 148,
+  height: 226,
   borderRadius: 14,
   boxShadow: '0px 10px 20px 0px #0000000D',
   cursor: 'pointer',
   '@media': {
+    'screen and (min-width: 640px)': {
+      maxWidth: 255,
+    },
     'screen and (min-width: 1024px)': {
+      height: 338,
       borderRadius: 20,
     },
   },
@@ -19,8 +23,13 @@ export const postCard = style({
 export const imageBox = style({
   position: 'relative',
   width: '100%',
-  paddingTop: '60%',
+  height: 95,
   overflow: 'hidden',
+  '@media': {
+    'screen and (min-width: 1024px)': {
+      height: 150,
+    },
+  },
 });
 
 export const image = style({
@@ -71,14 +80,17 @@ export const contentContainer = style({
 });
 
 export const title = style({
-  fontSize: 'clamp(12px, 1.67vw, 18px)',
+  height: 15,
+  fontSize: 12,
   fontWeight: 700,
   marginTop: 5,
   whiteSpace: 'nowrap',
-  overflow: 'hidden',
   textOverflow: 'ellipsis',
+  overflow: 'hidden',
   '@media': {
     'screen and (min-width: 1024px)': {
+      height: 21,
+      fontSize: 18,
       marginTop: 10,
     },
   },
@@ -88,11 +100,13 @@ export const infoContainer = style({
   width: '100%',
   display: 'flex',
   marginTop: 5,
-  alignItems: 'center',
-  fontSize: 'clamp(10px, 1.3vw, 14px)',
+  fontSize: 10,
+  fontWeight: 400,
+  alignContent: 'center',
   '@media': {
     'screen and (min-width: 1024px)': {
       marginTop: 10,
+      fontSize: 14,
     },
   },
 });

--- a/src/styles/components/common/board-card.css.ts
+++ b/src/styles/components/common/board-card.css.ts
@@ -2,16 +2,15 @@ import { vars } from '@/styles/globalTheme.css';
 import { style } from '@vanilla-extract/css';
 
 export const postCard = style({
-  display: 'inline-block',
-  width: 160,
-  height: 226,
-  borderRadius: 10,
+  display: 'block',
+  width: '100%',
+  maxWidth: 255,
+  height: 'auto', // 비율 유지를 위해 auto로 변경
+  borderRadius: 14,
   boxShadow: '0px 10px 20px 0px #0000000D',
   cursor: 'pointer',
   '@media': {
     'screen and (min-width: 1024px)': {
-      width: 255,
-      height: 338,
       borderRadius: 20,
     },
   },
@@ -20,16 +19,17 @@ export const postCard = style({
 export const imageBox = style({
   position: 'relative',
   width: '100%',
-  height: 95,
+  paddingTop: '60%',
   overflow: 'hidden',
-  '@media': {
-    'screen and (min-width: 1024px)': {
-      height: 150,
-    },
-  },
 });
 
 export const image = style({
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  width: '100%',
+  height: '100%',
+  objectFit: 'cover',
   borderRadius: '10px 10px 0px 0px',
   '@media': {
     'screen and (min-width: 1024px)': {
@@ -56,43 +56,43 @@ export const bookMark = style({
 });
 
 export const contentContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
+  width: 'calc(100% - 20px)',
   padding: '10px 10px',
   background: vars.color.white,
   borderRadius: 10,
   '@media': {
     'screen and (min-width: 1024px)': {
       padding: '15px 20px',
+      width: 'calc(100% - 30px)',
     },
   },
 });
 
 export const title = style({
-  display: 'flex',
-  height: 15,
-  fontSize: 12,
+  fontSize: 'clamp(12px, 1.67vw, 18px)',
   fontWeight: 700,
   marginTop: 5,
-  justifyItems: 'center',
+  whiteSpace: 'nowrap',
   overflow: 'hidden',
+  textOverflow: 'ellipsis',
   '@media': {
     'screen and (min-width: 1024px)': {
-      height: 21,
-      fontSize: 18,
       marginTop: 10,
     },
   },
 });
 
 export const infoContainer = style({
+  width: '100%',
   display: 'flex',
   marginTop: 5,
-  fontSize: 10,
-  fontWeight: 400,
-  alignContent: 'center',
+  alignItems: 'center',
+  fontSize: 'clamp(10px, 1.3vw, 14px)',
   '@media': {
     'screen and (min-width: 1024px)': {
       marginTop: 10,
-      fontSize: 14,
     },
   },
 });

--- a/src/styles/components/common/board-card.css.ts
+++ b/src/styles/components/common/board-card.css.ts
@@ -1,5 +1,5 @@
 import { vars } from '@/styles/globalTheme.css';
-import { style } from '@vanilla-extract/css';
+import { keyframes, style } from '@vanilla-extract/css';
 
 export const boardCard = style({
   display: 'block',
@@ -146,4 +146,56 @@ export const profileInfo = style({
       fontSize: 12,
     },
   },
+});
+
+//애니메이션 정의도 같은 파일에 추가
+const pulse = keyframes({
+  '0%': { opacity: 1 },
+  '50%': { opacity: 0.5 },
+  '100%': { opacity: 1 },
+});
+
+export const skeleton = style({
+  background: vars.color.g200,
+  color: vars.color.g200,
+  animation: `${pulse} 1.5s ease-in-out infinite`,
+});
+
+export const containerSkeleton = style({
+  height: 226,
+  '@media': {
+    'screen and (min-width: 1024px)': {
+      height: 338,
+    },
+  },
+});
+
+export const languageSkeleton = style({
+  width: 40,
+  height: 20,
+  borderRadius: 5,
+  '@media': {
+    'screen and (min-width: 1024px)': {
+      width: 50,
+      height: 24,
+    },
+  },
+});
+
+export const profileSkeleton = style({
+  width: 16,
+  height: 16,
+  borderRadius: 24,
+  overflow: 'hidden',
+  '@media': {
+    'screen and (min-width: 1024px)': {
+      width: 24,
+      height: 24,
+    },
+  },
+});
+
+export const profileInfoSkeleton = style({
+  flex: 1,
+  marginLeft: 5,
 });

--- a/src/styles/components/common/language.css.ts
+++ b/src/styles/components/common/language.css.ts
@@ -1,40 +1,36 @@
 import { vars } from '@/styles/globalTheme.css';
-import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
 
-export const text = style({
-  padding: '4px 5px',
-  fontFamily: vars.font.menu,
-  fontWeight: 'medium',
-  fontSize: 10,
-  color: vars.color.white,
-  '@media': {
-    'screen and (min-width: 1024px)': {
-      padding: '5px 6px',
-      fontSize: 12,
+export const text = recipe({
+  base: {
+    display: 'inline-flex',
+    borderRadius: 5,
+    padding: '4px 5px',
+    fontFamily: vars.font.menu,
+    fontWeight: 'medium',
+    fontSize: 10,
+    color: vars.color.white,
+    '@media': {
+      'screen and (min-width: 1024px)': {
+        padding: '5px 6px',
+        fontSize: 12,
+      },
     },
   },
-});
-
-export const koreanBox = style({
-  display: 'inline-flex',
-  borderRadius: 5,
-  background: `linear-gradient(45deg, #3688FF, #0038FF)`,
-});
-
-export const englishBox = style({
-  display: 'inline-flex',
-  borderRadius: 5,
-  background: `linear-gradient(45deg, #FFB74C, #FF7A00)`,
-});
-
-export const ChineseBox = style({
-  display: 'inline-flex',
-  borderRadius: 5,
-  background: `linear-gradient(45deg, #FF8D8D, #FF0000)`,
-});
-
-export const JapaneseBox = style({
-  display: 'inline-flex',
-  borderRadius: 5,
-  background: `linear-gradient(45deg, #908DFF, #9E00FF)`,
+  variants: {
+    language: {
+      korean: {
+        background: `linear-gradient(45deg, #3688FF, #0038FF)`,
+      },
+      english: {
+        background: `linear-gradient(45deg, #FFB74C, #FF7A00)`,
+      },
+      chinese: {
+        background: `linear-gradient(45deg, #FF8D8D, #FF0000)`,
+      },
+      japanese: {
+        background: `linear-gradient(45deg, #908DFF, #9E00FF)`,
+      },
+    },
+  },
 });

--- a/src/styles/country/page.css.ts
+++ b/src/styles/country/page.css.ts
@@ -106,14 +106,16 @@ export const more = style({
 
 export const boardContainer = style({
   display: 'grid',
-  gridTemplateColumns: 'repeat(auto-fill, minmax(160px, 1fr))',
-  justifyItems: 'center',
+  width: '100%',
+  gridTemplateColumns:
+    'calc((100% - 15px) / 2) calc((100% - 15px) / 2)',
   gap: 15,
   maxWidth: 1080,
   '@media': {
-    'screen and (min-width: 1024px)': {
+    'screen and (min-width: 640px)': {
       gap: 20,
-      gridTemplateColumns: 'repeat(auto-fill, minmax(255px, 1fr))',
+      gridTemplateColumns:
+        'calc((100% - 60px) / 4) calc((100% - 60px) / 4) calc((100% - 60px) / 4) calc((100% - 60px) / 4)',
     },
   },
 });


### PR DESCRIPTION
# 1. 동행글 CSS 수정
> board-card.css.ts, country/page.css.ts 변경

- **이전에는, 375px이하로 화면이 줄어들 경우, 부자연스럽게 동행글이 한줄로 배치되어 버림**
-> 가로길이가 줄어들면, 동행글 미리보기 컴포넌트도 가로길이 줄어들도록 설정하여 해결 (boardcard의 width: 100%로 바꿈)

- **gridTemplateColumn: autofill로 설정하여, 화면이 줄어들 경우 컴포넌트 사이 간격이 넓거나, 3개 1개 이렇게 배치되는 경우가 생겼음**
->  'calc((100% - 60px) / 4) calc((100% - 60px) / 4) calc((100% - 60px) / 4) calc((100% - 60px) / 4)' 와 같이 직접 4개 비율, 2개 비율 계산해서 BoardCard 배치,

- **640px미만에서는 2개씩 2줄 배치, 이상부터는 4개씩 1줄 배치**

### 2. 동행글 상세보기 서버 컴포넌트로 변경
> app/country/board/[id]/page.tsx, CommentInput.tsx, TravelerCard.tsx

- **기존 useEffect로 페이지 로딩될 때 데이터 받아오기**
-> page컴포넌트 자체를 서버 컴포넌트로 바꿔 페이지에서 바로 fetch, useModal 커스텀 훅은 모두 연관있는 클라이언트 컴포넌트(CommentInput, TravelerCard)로 옮김
-> 이 과정에서 모달 컴포넌트 수정
-> 해당 컴포넌트에 props로 넘겨주던 useModal 변수 없앰 

### 3. 모달 컴포넌트 수정
> components/common/ModalWrapper.tsx

- **기존의 모달은 꼭 페이지 상단에서만 호출해야 배경과 모달 위치가 제대로 적용되었음. (위치에 종속적임)**
-> react-dom의 createPortal 사용하여, react트리의 상단에 배치시킴. 이제 어느곳에서나 호출 가능.

### 4. useCountryStore 수정
> store/useCountryStore.ts, components/main/CountrySelect.tsx

- **메인페이지에서 나라 선택하고, 다음 페이지 갔다가 다시 메인 간 경우, 선택된 나라 리스트 결과가 그대로 적용됨**
-> 나라 선택 후 countryStore의 값을 초기화 시켜주어야 하지 않아서 생긴 문제.
-> initalize 함수 추가하여, CountrySelect가 mount 해제될때 initialize 함수 실행

- **연관 컴포넌트 수정**
-> CountrySearch에서 검색 후 검색어 없앰.
-> MoveToMain에서 대륙 클릭 시 메인으로 이동하여 대륙에 해당하는 나라 리스트(useCountryStore의 continent값을 설정함)보여줌
-> CountrySelect에서 useEffect로 useCountryStore의 continet값이 있으면, 바로 리스트 불러옴 (위의 로직을 위함)

### 5. BoardPreview Skeleton UI 적용
> components/country/BoardPreviewSkeleton.tsx, components/country/BoardPreview.tsx, board-card.css.ts

- **글 받아오는 로딩 시간이 .. 꽤 길어서 Skeleton UI적용하기로 결정
-> 기존의 `board-card css` 사용
-> board-card css에 `background: 회색`인 skeleton 스타일 추가
-> BoardPreview에서 isLoading 변수 설정. 처음엔 true, 데이터 로딩 후 false
