### PR TITLE
[fix/SWM-269] 프로젝트 전체 Layout 변경

### DIFF
--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -1,14 +1,12 @@
 import '@/styles/font.css';
 import * as styles from '@/styles/main/page.css';
 import Image from 'next/image';
-import TransparentHeader from '@/components/header/TransparentHeader';
 import CountrySearch from '@/components/main/CountrySearch';
 import CountrySelect from '@/components/main/CountrySelect';
 
 const Page = () => {
   return (
-    <main>
-      <TransparentHeader />
+    <>
       <div className={styles.bgContainer}>
         <Image
           className={styles.bg}
@@ -36,7 +34,7 @@ const Page = () => {
         </div>
         <CountrySelect />
       </div>
-    </main>
+    </>
   );
 };
 

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -1,4 +1,3 @@
-import '@/styles/font.css';
 import * as styles from '@/styles/main/page.css';
 import Image from 'next/image';
 import CountrySearch from '@/components/main/CountrySearch';

--- a/src/app/[country]/board/[id]/page.tsx
+++ b/src/app/[country]/board/[id]/page.tsx
@@ -1,6 +1,5 @@
 import Image from 'next/image';
 import '@/styles/font.css';
-import Header from '@/components/header/Header';
 import * as styles from '@/styles/country/board/id/page.css';
 import TravelerCard from '@/components/country/board/id/TravelerCard';
 import { Language } from '@/components/common/Language';
@@ -9,7 +8,6 @@ import CommentList from '@/components/common/CommentList';
 import { TripTypeButton } from '@/components/common/TripTypeButton';
 import AttributeBox from '@/components/country/board/id/AttributeBox';
 import { BoardDetailType } from '@/types/country/board';
-import { headers } from 'next/headers';
 import ScheduleButton from '@/components/country/board/id/ScheduleButton';
 import { getBoardDetail } from '@/utils/server/board';
 
@@ -18,14 +16,6 @@ const Page = async ({
 }: {
   params: { country: string; id: string };
 }) => {
-  // const headersList = headers();
-  // const host = headersList.get('host');
-  // const protocol = process.env.NODE_ENV === 'production' ? 'https' : 'http';
-
-  // const boardData = await fetch(
-  //   `${protocol}://${host}/api/board?boardId=${params.id}`,
-  // ).then((res) => res.json());
-
   const boardData = await getBoardDetail(params.id);
 
   const boardDetail: BoardDetailType = boardData.data;
@@ -40,113 +30,110 @@ const Page = async ({
   };
 
   return (
-    <main>
-      <Header />
-      <div className={styles.pageContainer}>
-        <div className={styles.imageContainer}>
-          <Image
-            className={styles.image}
-            src={boardDetail.imageUrl || '/images/emptyBackground.png'}
-            alt="boardImage"
-            fill
-            sizes="1920px"
-          />
-        </div>
-        <div className={styles.container}>
-          <div className={styles.contentContainer}>
-            <Language language={boardDetail.language} />
-            <p className={styles.title}>{boardDetail.title}</p>
-            <div>
-              <span className={styles.iconContainer}>
-                <Image
-                  className={styles.icon}
-                  src="/icons/user.svg"
-                  width={20}
-                  height={20}
-                  alt="userIcon"
-                />
-                <span>{`${boardDetail.currentCount} / ${boardDetail.maxCount} 인`}</span>
-              </span>
-              <span className={styles.iconContainer}>
-                <Image
-                  className={styles.icon}
-                  src="/icons/comment.svg"
-                  width={20}
-                  height={20}
-                  alt="commendIcon"
-                />
-                <span>{boardDetail.commentCount}</span>
-              </span>
-            </div>
-            {hasTripStyle() && (
-              <div className={styles.infoContainer}>
-                <p className={styles.infoTitle}>동행자 특성</p>
-                <div className={styles.infoItem}>
-                  <AttributeBox
-                    props={{
-                      preferGender: boardDetail.preferGender,
-                      preferSmoking: boardDetail.preferSmoking,
-                      preferBudget: boardDetail.preferBudget,
-                      preferPhoto: boardDetail.preferPhoto,
-                      preferDrink: boardDetail.preferDrink,
-                    }}
-                  />
-                </div>
-              </div>
-            )}
-            {boardDetail.tripType.length > 0 && (
-              <div className={styles.infoContainer}>
-                <p className={styles.infoTitle}>동행 타입</p>
-                <div className={styles.infoItem}>
-                  {boardDetail.tripType.map((type) => (
-                    <TripTypeButton
-                      key={type}
-                      isButton={false}
-                      isSelected={true}
-                      type={type}
-                    />
-                  ))}
-                </div>
-              </div>
-            )}
-            <ScheduleButton
-              startDate={boardDetail.startDate}
-              endDate={boardDetail.endDate}
-              boardId={boardDetail.boardId}
-              country={boardDetail.countryName}
-            />
+    <>
+      <div className={styles.imageContainer}>
+        <Image
+          className={styles.image}
+          src={boardDetail.imageUrl || '/images/emptyBackground.png'}
+          alt="boardImage"
+          fill
+          sizes="1920px"
+        />
+      </div>
+      <div className={styles.container}>
+        <div className={styles.contentContainer}>
+          <Language language={boardDetail.language} />
+          <p className={styles.title}>{boardDetail.title}</p>
+          <div>
+            <span className={styles.iconContainer}>
+              <Image
+                className={styles.icon}
+                src="/icons/user.svg"
+                width={20}
+                height={20}
+                alt="userIcon"
+              />
+              <span>{`${boardDetail.currentCount} / ${boardDetail.maxCount} 인`}</span>
+            </span>
+            <span className={styles.iconContainer}>
+              <Image
+                className={styles.icon}
+                src="/icons/comment.svg"
+                width={20}
+                height={20}
+                alt="commendIcon"
+              />
+              <span>{boardDetail.commentCount}</span>
+            </span>
+          </div>
+          {hasTripStyle() && (
             <div className={styles.infoContainer}>
-              <p className={styles.infoTitle}>내용</p>
-              <div className={styles.infoContent}>{boardDetail.content}</div>
+              <p className={styles.infoTitle}>동행자 특성</p>
+              <div className={styles.infoItem}>
+                <AttributeBox
+                  props={{
+                    preferGender: boardDetail.preferGender,
+                    preferSmoking: boardDetail.preferSmoking,
+                    preferBudget: boardDetail.preferBudget,
+                    preferPhoto: boardDetail.preferPhoto,
+                    preferDrink: boardDetail.preferDrink,
+                  }}
+                />
+              </div>
             </div>
-          </div>
-          <TravelerCard
-            props={{
-              userImageUrl: boardDetail.userImageUrl,
-              nickName: boardDetail.nickName,
-              userId: boardDetail.userId,
-              ageRange: boardDetail.ageRange,
-              gender: boardDetail.gender,
-              nationality: boardDetail.nationality,
-              selfIntroduction: boardDetail.selfIntroduction ?? '',
-            }}
+          )}
+          {boardDetail.tripType.length > 0 && (
+            <div className={styles.infoContainer}>
+              <p className={styles.infoTitle}>동행 타입</p>
+              <div className={styles.infoItem}>
+                {boardDetail.tripType.map((type) => (
+                  <TripTypeButton
+                    key={type}
+                    isButton={false}
+                    isSelected={true}
+                    type={type}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+          <ScheduleButton
+            startDate={boardDetail.startDate}
+            endDate={boardDetail.endDate}
+            boardId={boardDetail.boardId}
+            country={boardDetail.countryName}
           />
-        </div>
-        <div className={styles.container}>
-          <div className={styles.commentContainer}>
-            <p className={styles.commentTitle}>
-              {'댓글 '}
-              <strong className={styles.commentTitleStrong}>
-                {boardDetail.commentCount}
-              </strong>
-              {' 개'}
-            </p>
-            <CommentInput id={boardDetail.boardId} />
-            <CommentList comments={boardDetail.boardComments} />
+          <div className={styles.infoContainer}>
+            <p className={styles.infoTitle}>내용</p>
+            <div className={styles.infoContent}>{boardDetail.content}</div>
           </div>
+        </div>
+        <TravelerCard
+          props={{
+            userImageUrl: boardDetail.userImageUrl,
+            nickName: boardDetail.nickName,
+            userId: boardDetail.userId,
+            ageRange: boardDetail.ageRange,
+            gender: boardDetail.gender,
+            nationality: boardDetail.nationality,
+            selfIntroduction: boardDetail.selfIntroduction ?? '',
+          }}
+        />
+      </div>
+      <div className={styles.container}>
+        <div className={styles.commentContainer}>
+          <p className={styles.commentTitle}>
+            {'댓글 '}
+            <strong className={styles.commentTitleStrong}>
+              {boardDetail.commentCount}
+            </strong>
+            {' 개'}
+          </p>
+          <CommentInput id={boardDetail.boardId} />
+          <CommentList comments={boardDetail.boardComments} />
         </div>
       </div>
-    </main>
+    </>
   );
 };
 

--- a/src/app/[country]/board/[id]/page.tsx
+++ b/src/app/[country]/board/[id]/page.tsx
@@ -1,5 +1,4 @@
 import Image from 'next/image';
-import '@/styles/font.css';
 import * as styles from '@/styles/country/board/id/page.css';
 import TravelerCard from '@/components/country/board/id/TravelerCard';
 import { Language } from '@/components/common/Language';

--- a/src/app/[country]/board/page.tsx
+++ b/src/app/[country]/board/page.tsx
@@ -1,33 +1,29 @@
 import '@/styles/font.css';
 import * as country from '@/styles/country/page.css';
 import * as styles from '@/styles/country/board/page.css';
-import Header from '@/components/header/Header';
 import CountryBackground from '@/components/country/CountryBackground';
 import BoardList from '@/components/country/board/BoardList';
 import CountryWrite from '@/components/common/CountryWrite';
 
 const Page = () => {
   return (
-    <main>
-      <Header />
-      <div className={country.pageContainer}>
-        <CountryBackground />
-        <div className={styles.bgOverlay}>
-          <div className={styles.mapContainer}>
-            <span className={styles.mapText}>
-              지도를 통해
-              <br />
-              주위 동행을 찾아보세요!
-            </span>
-            <button className={styles.mapButton}>{'지도로 동행 찾기 >'}</button>
-          </div>
-        </div>
-        <div className={country.contentContainer}>
-          <BoardList />
+    <>
+      <CountryBackground />
+      <div className={styles.bgOverlay}>
+        <div className={styles.mapContainer}>
+          <span className={styles.mapText}>
+            지도를 통해
+            <br />
+            주위 동행을 찾아보세요!
+          </span>
+          <button className={styles.mapButton}>{'지도로 동행 찾기 >'}</button>
         </div>
       </div>
+      <div className={country.contentContainer}>
+        <BoardList />
+      </div>
       <CountryWrite type="board" />
-    </main>
+    </>
   );
 };
 

--- a/src/app/[country]/board/page.tsx
+++ b/src/app/[country]/board/page.tsx
@@ -1,4 +1,3 @@
-import '@/styles/font.css';
 import * as country from '@/styles/country/page.css';
 import * as styles from '@/styles/country/board/page.css';
 import CountryBackground from '@/components/country/CountryBackground';

--- a/src/app/[country]/layout.tsx
+++ b/src/app/[country]/layout.tsx
@@ -1,0 +1,9 @@
+import { pageContainer } from '@/styles/country/page.css';
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <div className={pageContainer}>{children}</div>;
+}

--- a/src/app/[country]/page.tsx
+++ b/src/app/[country]/page.tsx
@@ -1,4 +1,3 @@
-import '@/styles/font.css';
 import * as styles from '@/styles/country/page.css';
 import BoardPreview from '@/components/country/BoardPreview';
 import CountryBackground from '@/components/country/CountryBackground';

--- a/src/app/[country]/page.tsx
+++ b/src/app/[country]/page.tsx
@@ -1,24 +1,20 @@
 import '@/styles/font.css';
 import * as styles from '@/styles/country/page.css';
-import Header from '@/components/header/Header';
 import BoardPreview from '@/components/country/BoardPreview';
 import CountryBackground from '@/components/country/CountryBackground';
 import PostPreview from '@/components/country/PostPreivew';
 
 const Page = () => {
   return (
-    <main>
-      <Header />
-      <div className={styles.pageContainer}>
-        <CountryBackground />
-        <div className={styles.contentContainer}>
-          <BoardPreview />
-          <PostPreview type="restaurant" />
-          <PostPreview type="rentalHome" />
-          <PostPreview type="schedule" />
-        </div>
+    <>
+      <CountryBackground />
+      <div className={styles.contentContainer}>
+        <BoardPreview />
+        <PostPreview type="restaurant" />
+        <PostPreview type="rentalHome" />
+        <PostPreview type="schedule" />
       </div>
-    </main>
+    </>
   );
 };
 

--- a/src/app/[country]/post/[id]/page.tsx
+++ b/src/app/[country]/post/[id]/page.tsx
@@ -1,6 +1,5 @@
 import Image from 'next/image';
 import '@/styles/font.css';
-import Header from '@/components/header/Header';
 import * as styles from '@/styles/country/board/id/page.css';
 import TravelerCard from '@/components/country/board/id/TravelerCard';
 import CommentInput from '@/components/common/CommentInput';
@@ -26,62 +25,59 @@ const Page = async ({
   const postDetail: PostDetailType = postData.data;
 
   return (
-    <main>
-      <Header />
-      <div className={styles.pageContainer}>
-        <div className={styles.container}>
-          <div className={styles.contentContainer}>
-            <p className={styles.title}>{postDetail.title}</p>
-            <div>
-              <Like
-                isLike={postDetail.myLikeState}
-                likeCount={postDetail.likeCount}
+    <>
+      <div className={styles.container}>
+        <div className={styles.contentContainer}>
+          <p className={styles.title}>{postDetail.title}</p>
+          <div>
+            <Like
+              isLike={postDetail.myLikeState}
+              likeCount={postDetail.likeCount}
+            />
+            <span className={styles.iconContainer}>
+              <Image
+                className={styles.icon}
+                src="/icons/comment.svg"
+                width={20}
+                height={20}
+                alt="commendIcon"
               />
-              <span className={styles.iconContainer}>
-                <Image
-                  className={styles.icon}
-                  src="/icons/comment.svg"
-                  width={20}
-                  height={20}
-                  alt="commendIcon"
-                />
-                <span>{postDetail.commentCount}</span>
-              </span>
-            </div>
-            <div className={styles.infoContainer}>
-              <p className={styles.infoTitle}>내용</p>
-              <div className={styles.infoContent}>{postDetail.content}</div>
-            </div>
+              <span>{postDetail.commentCount}</span>
+            </span>
           </div>
-          <TravelerCard
-            props={{
-              userImageUrl: postDetail.userImageUrl,
-              nickName: postDetail.userNickName,
-              userId: 0,
-              ageRange: postDetail.userAgeRange,
-              gender: postDetail.userGender,
-              nationality: postDetail.userNationality,
-              selfIntroduction: postDetail.selfIntroduce ?? '',
-            }}
-            title="작성자"
-            type="post"
-          />
+          <div className={styles.infoContainer}>
+            <p className={styles.infoTitle}>내용</p>
+            <div className={styles.infoContent}>{postDetail.content}</div>
+          </div>
         </div>
-        <div className={styles.container}>
-          <div className={styles.commentContainer}>
-            <p className={styles.commentTitle}>
-              {'댓글 '}
-              <strong className={styles.commentTitleStrong}>
-                {postDetail.commentCount}
-              </strong>
-              {' 개'}
-            </p>
-            <CommentInput id={postDetail.postingId} type="post" />
-            <CommentList comments={postDetail.postingComments} />
-          </div>
+        <TravelerCard
+          props={{
+            userImageUrl: postDetail.userImageUrl,
+            nickName: postDetail.userNickName,
+            userId: 0,
+            ageRange: postDetail.userAgeRange,
+            gender: postDetail.userGender,
+            nationality: postDetail.userNationality,
+            selfIntroduction: postDetail.selfIntroduce ?? '',
+          }}
+          title="작성자"
+          type="post"
+        />
+      </div>
+      <div className={styles.container}>
+        <div className={styles.commentContainer}>
+          <p className={styles.commentTitle}>
+            {'댓글 '}
+            <strong className={styles.commentTitleStrong}>
+              {postDetail.commentCount}
+            </strong>
+            {' 개'}
+          </p>
+          <CommentInput id={postDetail.postingId} type="post" />
+          <CommentList comments={postDetail.postingComments} />
         </div>
       </div>
-    </main>
+    </>
   );
 };
 

--- a/src/app/[country]/post/[id]/page.tsx
+++ b/src/app/[country]/post/[id]/page.tsx
@@ -1,5 +1,4 @@
 import Image from 'next/image';
-import '@/styles/font.css';
 import * as styles from '@/styles/country/board/id/page.css';
 import TravelerCard from '@/components/country/board/id/TravelerCard';
 import CommentInput from '@/components/common/CommentInput';

--- a/src/app/[country]/post/layout.tsx
+++ b/src/app/[country]/post/layout.tsx
@@ -1,7 +1,0 @@
-export default function RootLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
-  return <>{children}</>;
-}

--- a/src/app/[country]/post/page.tsx
+++ b/src/app/[country]/post/page.tsx
@@ -1,4 +1,3 @@
-import '@/styles/font.css';
 import * as country from '@/styles/country/page.css';
 import CountryBackground from '@/components/country/CountryBackground';
 import PostCardList from '@/components/country/post/PostCardList';

--- a/src/app/[country]/post/page.tsx
+++ b/src/app/[country]/post/page.tsx
@@ -1,23 +1,18 @@
-import Image from 'next/image';
 import '@/styles/font.css';
 import * as country from '@/styles/country/page.css';
-import Header from '@/components/header/Header';
 import CountryBackground from '@/components/country/CountryBackground';
 import PostCardList from '@/components/country/post/PostCardList';
 import CountryWrite from '@/components/common/CountryWrite';
 
 const Page = () => {
   return (
-    <main>
-      <Header />
-      <div className={country.pageContainer}>
-        <CountryBackground />
-        <div className={country.contentContainer}>
-          <PostCardList />
-        </div>
+    <>
+      <CountryBackground />
+      <div className={country.contentContainer}>
+        <PostCardList />
       </div>
       <CountryWrite type="post" />
-    </main>
+    </>
   );
 };
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -22,7 +22,7 @@ export default function RootLayout({
       <body>
         <Initializer />
         <ConditionalHeader />
-        {children}
+        <main>{children}</main>
       </body>
     </html>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import Initializer from '@/components/common/Initializer';
+import ConditionalHeader from '@/components/header/ConditionalHeader';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
@@ -20,6 +21,7 @@ export default function RootLayout({
       </head>
       <body>
         <Initializer />
+        <ConditionalHeader />
         {children}
       </body>
     </html>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import Initializer from '@/components/common/Initializer';
 import ConditionalHeader from '@/components/header/ConditionalHeader';
 import type { Metadata } from 'next';
+import '@/styles/font.css';
 
 export const metadata: Metadata = {
   title: 'TripMingle',

--- a/src/app/login/kakao/page.tsx
+++ b/src/app/login/kakao/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 import { kakaoLogin } from '@/api/user';
-import NonProfileHeader from '@/components/header/NonProfileHeader';
 import { useUserStore } from '@/store/userStore';
 import { pageContainer } from '@/styles/login/page.css';
 import { removeKakaoAuthorization } from '@/utils/server/token';
@@ -49,12 +48,7 @@ const Page = () => {
     }
   }, []);
 
-  return (
-    <>
-      <NonProfileHeader />
-      <div className={pageContainer}>{isLoading ? '로그인중' : result}</div>
-    </>
-  );
+  return <div className={pageContainer}>{isLoading ? '로그인중' : result}</div>;
 };
 
 export default Page;

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,5 +1,4 @@
 'use client';
-import '@/styles/font.css';
 import * as styles from '@/styles/login/page.css';
 import Image from 'next/image';
 

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 import '@/styles/font.css';
-import NonProfileHeader from '@/components/header/NonProfileHeader';
 import * as styles from '@/styles/login/page.css';
 import Image from 'next/image';
 
@@ -12,7 +11,6 @@ const Page = () => {
 
   return (
     <>
-      <NonProfileHeader />
       <div className={styles.pageContainer}>
         <p className={styles.logo}>TripMingle</p>
         <span className={styles.explain}>로그인하고 여행을 계속해요</span>

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,5 +1,4 @@
 'use client';
-import '@/styles/font.css';
 import * as styles from '@/styles/signup/page.css';
 import { useRouter } from 'next/navigation';
 import { useUserStore } from '@/store/userStore';

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 import '@/styles/font.css';
-import NonProfileHeader from '@/components/header/NonProfileHeader';
 import * as styles from '@/styles/signup/page.css';
 import { useRouter } from 'next/navigation';
 import { useUserStore } from '@/store/userStore';
@@ -87,7 +86,6 @@ const Page = () => {
 
   return (
     <>
-      <NonProfileHeader />
       <div className={styles.pageContainer}>
         <p className={styles.text}>환영합니다!</p>
         <span className={styles.explain}>

--- a/src/app/write/board/page.tsx
+++ b/src/app/write/board/page.tsx
@@ -1,9 +1,8 @@
 'use client';
 import '@/styles/font.css';
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import { useForm, FormProvider } from 'react-hook-form';
 import * as styles from '@/styles/write/page.css';
-import Header from '@/components/header/Header';
 import { BoardForm, boardFormDefault } from '@/types/country/board';
 import { SchedulePlaceType } from '@/types/country/place';
 import CountrySearch from '@/components/write/board/firststep/CountrySearch';
@@ -100,28 +99,25 @@ const Page = () => {
   ];
 
   return (
-    <main>
-      <Header />
-      <div className={styles.pageContainer}>
-        <div className={styles.pageContent}>
-          <Progress currentStep={step} allStep={4} />
-          <p className={styles.explainText}>{explains[step - 1]}</p>
-          <FormProvider {...methods}>
-            <div className={styles.contentContainer} ref={pageContentRef}>
-              {components[step - 1]}
-            </div>
-            <StepButton
-              step={step}
-              content={content}
-              searchCountry={searchCountry}
-              placeList={placeList}
-              stepHandler={stepHandler}
-              searchHandler={countrySearchHandler}
-            />
-          </FormProvider>
-        </div>
+    <div className={styles.pageContainer}>
+      <div className={styles.pageContent}>
+        <Progress currentStep={step} allStep={4} />
+        <p className={styles.explainText}>{explains[step - 1]}</p>
+        <FormProvider {...methods}>
+          <div className={styles.contentContainer} ref={pageContentRef}>
+            {components[step - 1]}
+          </div>
+          <StepButton
+            step={step}
+            content={content}
+            searchCountry={searchCountry}
+            placeList={placeList}
+            stepHandler={stepHandler}
+            searchHandler={countrySearchHandler}
+          />
+        </FormProvider>
       </div>
-    </main>
+    </div>
   );
 };
 

--- a/src/app/write/board/page.tsx
+++ b/src/app/write/board/page.tsx
@@ -1,5 +1,4 @@
 'use client';
-import '@/styles/font.css';
 import { useRef, useState } from 'react';
 import { useForm, FormProvider } from 'react-hook-form';
 import * as styles from '@/styles/write/page.css';

--- a/src/app/write/board/page.tsx
+++ b/src/app/write/board/page.tsx
@@ -99,25 +99,23 @@ const Page = () => {
   ];
 
   return (
-    <div className={styles.pageContainer}>
-      <div className={styles.pageContent}>
-        <Progress currentStep={step} allStep={4} />
-        <p className={styles.explainText}>{explains[step - 1]}</p>
-        <FormProvider {...methods}>
-          <div className={styles.contentContainer} ref={pageContentRef}>
-            {components[step - 1]}
-          </div>
-          <StepButton
-            step={step}
-            content={content}
-            searchCountry={searchCountry}
-            placeList={placeList}
-            stepHandler={stepHandler}
-            searchHandler={countrySearchHandler}
-          />
-        </FormProvider>
-      </div>
-    </div>
+    <>
+      <Progress currentStep={step} allStep={4} />
+      <p className={styles.explainText}>{explains[step - 1]}</p>
+      <FormProvider {...methods}>
+        <div className={styles.contentContainer} ref={pageContentRef}>
+          {components[step - 1]}
+        </div>
+        <StepButton
+          step={step}
+          content={content}
+          searchCountry={searchCountry}
+          placeList={placeList}
+          stepHandler={stepHandler}
+          searchHandler={countrySearchHandler}
+        />
+      </FormProvider>
+    </>
   );
 };
 

--- a/src/app/write/layout.tsx
+++ b/src/app/write/layout.tsx
@@ -1,0 +1,13 @@
+import { pageContainer, pageContent } from '@/styles/write/page.css';
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className={pageContainer}>
+      <div className={pageContent}>{children}</div>
+    </div>
+  );
+}

--- a/src/app/write/post/page.tsx
+++ b/src/app/write/post/page.tsx
@@ -68,25 +68,23 @@ const Page = () => {
   ];
 
   return (
-    <div className={styles.pageContainer}>
-      <div className={styles.pageContent}>
-        <Progress currentStep={step} allStep={2} />
-        <p className={styles.explainText}>{explains[step - 1]}</p>
-        <FormProvider {...methods}>
-          <div className={styles.contentContainer} ref={pageContentRef}>
-            {components[step - 1]}
-          </div>
-          <StepButton
-            step={step}
-            content={content}
-            searchCountry={searchCountry}
-            stepHandler={stepHandler}
-            searchHandler={countrySearchHandler}
-            contentHandler={contentHandler}
-          />
-        </FormProvider>
-      </div>
-    </div>
+    <>
+      <Progress currentStep={step} allStep={2} />
+      <p className={styles.explainText}>{explains[step - 1]}</p>
+      <FormProvider {...methods}>
+        <div className={styles.contentContainer} ref={pageContentRef}>
+          {components[step - 1]}
+        </div>
+        <StepButton
+          step={step}
+          content={content}
+          searchCountry={searchCountry}
+          stepHandler={stepHandler}
+          searchHandler={countrySearchHandler}
+          contentHandler={contentHandler}
+        />
+      </FormProvider>
+    </>
   );
 };
 

--- a/src/app/write/post/page.tsx
+++ b/src/app/write/post/page.tsx
@@ -1,5 +1,4 @@
 'use client';
-import '@/styles/font.css';
 import { useRef, useState } from 'react';
 import { useForm, FormProvider } from 'react-hook-form';
 import * as styles from '@/styles/write/page.css';

--- a/src/app/write/post/page.tsx
+++ b/src/app/write/post/page.tsx
@@ -3,7 +3,6 @@ import '@/styles/font.css';
 import { useRef, useState } from 'react';
 import { useForm, FormProvider } from 'react-hook-form';
 import * as styles from '@/styles/write/page.css';
-import Header from '@/components/header/Header';
 import CountrySearch from '@/components/write/board/firststep/CountrySearch';
 import CountryList from '@/components/write/post/firststep/CountryList';
 import ContentForm from '@/components/write/post/secondstep/ContentForm';
@@ -69,28 +68,25 @@ const Page = () => {
   ];
 
   return (
-    <main>
-      <Header />
-      <div className={styles.pageContainer}>
-        <div className={styles.pageContent}>
-          <Progress currentStep={step} allStep={2} />
-          <p className={styles.explainText}>{explains[step - 1]}</p>
-          <FormProvider {...methods}>
-            <div className={styles.contentContainer} ref={pageContentRef}>
-              {components[step - 1]}
-            </div>
-            <StepButton
-              step={step}
-              content={content}
-              searchCountry={searchCountry}
-              stepHandler={stepHandler}
-              searchHandler={countrySearchHandler}
-              contentHandler={contentHandler}
-            />
-          </FormProvider>
-        </div>
+    <div className={styles.pageContainer}>
+      <div className={styles.pageContent}>
+        <Progress currentStep={step} allStep={2} />
+        <p className={styles.explainText}>{explains[step - 1]}</p>
+        <FormProvider {...methods}>
+          <div className={styles.contentContainer} ref={pageContentRef}>
+            {components[step - 1]}
+          </div>
+          <StepButton
+            step={step}
+            content={content}
+            searchCountry={searchCountry}
+            stepHandler={stepHandler}
+            searchHandler={countrySearchHandler}
+            contentHandler={contentHandler}
+          />
+        </FormProvider>
       </div>
-    </main>
+    </div>
   );
 };
 

--- a/src/components/common/CountryWrite.tsx
+++ b/src/components/common/CountryWrite.tsx
@@ -7,7 +7,6 @@ import useModal from '@/hooks/useModal';
 import { useUserStore } from '@/store/userStore';
 
 const CountryWrite = ({ type }: { type: string }) => {
-  // const [active, setActive] = useState<boolean>(false);
   const { isOpen, openModal, closeModal } = useModal();
   const isLoggedIn = useUserStore((state) => state.isLoggedIn);
   const router = useRouter();
@@ -22,33 +21,17 @@ const CountryWrite = ({ type }: { type: string }) => {
   return (
     <>
       <div className={styles.countryWriteContainer}>
-        <div className={styles.writeItemContainer}>
-          <div
-            className={styles.writeContainer({ active: false, type: 'board' })}
-            onClick={() => clickHandler('board')}
-          >
-            동행글
-          </div>
-          <div
-            className={styles.writeContainer({ active: false, type: 'post' })}
-            onClick={() => clickHandler('post')}
-          >
-            정보글
-          </div>
-          <div
-            onClick={() => clickHandler(type)}
-            className={styles.iconContainer}
-          >
-            <Image
-              className={styles.icon}
-              src="/icons/pencil.svg"
-              alt="writeIcon"
-              width={24}
-              height={24}
-            />
-          </div>
+        <div
+          onClick={() => clickHandler(type)}
+          className={styles.iconContainer}
+        >
+          <Image
+            src="/icons/pencil.svg"
+            alt="writeIcon"
+            width={24}
+            height={24}
+          />
         </div>
-        <p className={styles.writeText}>등록하기</p>
       </div>
       <LoginModal isOpen={isOpen} closeModal={closeModal} />
     </>

--- a/src/components/header/ConditionalHeader.tsx
+++ b/src/components/header/ConditionalHeader.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import TransparentHeader from './TransparentHeader';
+import NonProfileHeader from './NonProfileHeader';
+import Header from './Header';
+
+const ConditionalHeader = () => {
+  const pathname = usePathname();
+
+  // 경로에 따른 헤더 컴포넌트 선택
+  if (pathname === '/') {
+    return <TransparentHeader />;
+  }
+
+  if (pathname === '/login' || pathname === '/signup') {
+    return <NonProfileHeader />;
+  }
+
+  return <Header />;
+};
+
+export default ConditionalHeader;

--- a/src/styles/components/common/countryWrite.css.ts
+++ b/src/styles/components/common/countryWrite.css.ts
@@ -1,10 +1,8 @@
 import { vars } from '@/styles/globalTheme.css';
 import { style } from '@vanilla-extract/css';
-import { recipe } from '@vanilla-extract/recipes';
 
 export const countryWriteContainer = style({
-  position: 'fixed',
-  right: 10,
+  position: 'sticky',
   bottom: 20,
   display: 'flex',
   flexDirection: 'column',
@@ -12,36 +10,7 @@ export const countryWriteContainer = style({
   cursor: 'pointer',
   '@media': {
     'screen and (min-width: 1024px)': {
-      right: 20,
       bottom: 60,
-    },
-    'screen and (min-width: 1200px)': {
-      right: 'calc((100vw - 1200px)/2)',
-      bottom: 60,
-    },
-  },
-});
-
-export const writeText = style({
-  display: 'none',
-  '@media': {
-    'screen and (min-width: 1024px)': {
-      display: 'flex',
-      color: vars.color.secondary,
-      fontWeight: 500,
-      fontSize: 14,
-    },
-  },
-});
-
-export const writeItemContainer = style({
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 14,
-  alignItems: 'center',
-  '@media': {
-    'screen and (min-width: 1024px)': {
-      gap: 20,
     },
   },
 });
@@ -50,6 +19,8 @@ export const iconContainer = style({
   display: 'flex',
   justifyContent: 'center',
   alignItems: 'center',
+  marginLeft: 'auto',
+  marginRight: 10,
   width: 42,
   height: 42,
   zIndex: 10,
@@ -59,121 +30,10 @@ export const iconContainer = style({
     'screen and (min-width: 1024px)': {
       width: 48,
       height: 48,
+      marginRight: 20,
+    },
+    'screen and (min-width: 1200px)': {
+      marginRight: 'calc((100vw - 1200px)/2)',
     },
   },
 });
-
-export const icon = style({});
-
-export const writeContainer = recipe({
-  base: {
-    position: 'absolute',
-    display: 'flex',
-    justifyContent: 'center',
-    alignItems: 'center',
-    width: 36,
-    height: 36,
-    zIndex: 3,
-    borderRadius: '50%',
-    background: vars.color.white,
-    fontFamily: vars.font.menu,
-    fontWeight: 'normal',
-    fontSize: 10,
-    color: vars.color.secondary,
-    transition: 'all 0.5s ease',
-    '@media': {
-      'screen and (min-width: 1024px)': {
-        fontSize: 12,
-        width: 42,
-        height: 42,
-      },
-    },
-  },
-  variants: {
-    active: {
-      true: {
-        border: `1px solid rgba(54, 136, 255, 0.2)`,
-        boxShadow: `0px 5px 10px 0px rgba(54, 136, 255, 0.3)`,
-      },
-      false: { bottom: 0 },
-    },
-    type: {
-      board: {
-        bottom: 52,
-        '@media': {
-          'screen and (min-width: 1024px)': {
-            bottom: 84,
-          },
-        },
-      },
-      post: {
-        bottom: 100,
-        '@media': {
-          'screen and (min-width: 1024px)': {
-            bottom: 140,
-          },
-        },
-      },
-    },
-  },
-  compoundVariants: [
-    {
-      variants: {
-        active: false,
-        type: 'board',
-      },
-      style: {
-        bottom: 0,
-        '@media': {
-          'screen and (min-width: 1024px)': {
-            bottom: 20,
-          },
-        },
-      },
-    },
-    {
-      variants: {
-        active: false,
-        type: 'post',
-      },
-      style: {
-        bottom: 0,
-        '@media': {
-          'screen and (min-width: 1024px)': {
-            bottom: 20,
-          },
-        },
-      },
-    },
-    {
-      variants: {
-        active: true,
-        type: 'board',
-      },
-      style: {
-        bottom: 52,
-        '@media': {
-          'screen and (min-width: 1024px)': {
-            bottom: 84,
-          },
-        },
-      },
-    },
-    {
-      variants: {
-        active: true,
-        type: 'post',
-      },
-      style: {
-        bottom: 100,
-        '@media': {
-          'screen and (min-width: 1024px)': {
-            bottom: 140,
-          },
-        },
-      },
-    },
-  ],
-});
-
-export const postWriteContainer = style({});

--- a/src/styles/country/board/id/page.css.ts
+++ b/src/styles/country/board/id/page.css.ts
@@ -1,19 +1,6 @@
 import { vars } from '@/styles/globalTheme.css';
 import { style } from '@vanilla-extract/css';
 
-export const pageContainer = style({
-  position: 'relative',
-  top: 44,
-  left: '50%',
-  transform: 'translate(-50%,0)',
-  '@media': {
-    'screen and (min-width: 1024px)': {
-      top: 60,
-      maxWidth: 1920,
-    },
-  },
-});
-
 export const imageContainer = style({
   position: 'relative',
   width: '100%',
@@ -172,4 +159,3 @@ export const commentTitleStrong = style({
   fontWeight: 700,
   color: vars.color.secondary,
 });
-

--- a/src/styles/globalTheme.css.ts
+++ b/src/styles/globalTheme.css.ts
@@ -1,8 +1,4 @@
-import {
-  StyleRule,
-  createGlobalTheme,
-  globalStyle,
-} from '@vanilla-extract/css';
+import { createGlobalTheme, globalStyle } from '@vanilla-extract/css';
 
 export const vars = createGlobalTheme(':root', {
   color: {

--- a/src/styles/globalTheme.css.ts
+++ b/src/styles/globalTheme.css.ts
@@ -47,3 +47,16 @@ globalStyle('p', {
   margin: 0,
 });
 
+globalStyle('::-webkit-scrollbar', {
+  width: 6,
+});
+
+globalStyle('::-webkit-scrollbar-track', {
+  background: 'transparent',
+  WebkitBoxShadow: 'none',
+});
+
+globalStyle('::-webkit-scrollbar-thumb', {
+  backgroundColor: vars.color.g500,
+  borderRadius: 10,
+});

--- a/src/styles/write/firststep/country-list.css.ts
+++ b/src/styles/write/firststep/country-list.css.ts
@@ -43,15 +43,11 @@ export const countryContainer = recipe({
 });
 
 export const resultContainer = style({
-  height: 'calc(100% - 76px)',
+  flex: 1,
+  paddingTop: 20,
   paddingBottom: 20,
-  overflow: 'scroll',
+  overflowY: 'auto',
   boxSizing: 'border-box',
-  '@media': {
-    'screen and (min-width: 1024px)': {
-      height: 'calc(100% - 120px)',
-    },
-  },
 });
 
 export const listContainer = style({

--- a/src/styles/write/page.css.ts
+++ b/src/styles/write/page.css.ts
@@ -4,14 +4,15 @@ import { style } from '@vanilla-extract/css';
 export const pageContainer = style({
   position: 'relative',
   display: 'flex',
-  top: 44,
-  height: 'calc(100vh - 40px)',
+  padding: '74px 20px 30px 20px',
+  width: '100%',
+  height: '100vh',
   flexDirection: 'column',
   alignItems: 'center',
+  boxSizing: 'border-box',
   '@media': {
     'screen and (min-width: 1024px)': {
-      top: 60,
-      height: 'calc(100vh - 60px)',
+      padding: '100px 0px 40px 0px',
     },
   },
 });
@@ -19,24 +20,26 @@ export const pageContainer = style({
 export const pageContent = style({
   display: 'flex',
   flexDirection: 'column',
-  padding: '30px 20px',
+  padding: '0px 20px',
   width: '100%',
   maxWidth: 540,
   height: '100%',
   boxSizing: 'border-box',
+  overflow: 'hidden',
   '@media': {
     'screen and (min-width: 1024px)': {
-      padding: '40px 0px',
+      padding: '0px 0px',
       maxWidth: 720,
     },
   },
 });
 
 export const contentContainer = style({
+  display: 'flex',
+  flexDirection: 'column',
   flex: 1,
   margin: '20px 0px',
-  overflowX: 'hidden',
-  overflowY: 'scroll',
+  overflowY: 'auto',
   '@media': {
     'screen and (min-width: 1024px)': {
       margin: '40px 0px',

--- a/src/styles/write/post.css.ts
+++ b/src/styles/write/post.css.ts
@@ -1,3 +1,0 @@
-import { style } from '@vanilla-extract/css';
-import { vars } from '../globalTheme.css';
-


### PR DESCRIPTION
### 기존 방식의 문제점
- 헤더를 모든 페이지에서 import하고 항상 header를 제외한 부분에 pagecontainer라는 스타일을 적용하여, 헤더만큼의 padding을 항상 적용했음

## 최상단 레이아웃에서 헤더 적용
### ConditionalHeader
main, login, signup에서 사용하는 헤더는 다른 헤더와 달랐기 때문에, 페이지 위치에 따라 헤더를 다르게 호출해야했음.
pathname확인해서 return값 다르게 하는 방식으로 변경

### country
country 하위 페이지에서 에서 항상 main태그와 pagecontainer스타일을 적용했음 -> layout에 main과 pagecontainer적용하여 불필요한 반복 없앰.

### write
write는 기존 contentContainer에서 쓸데없이 다른 요소 제외 높이 계산하는 부분을 없애고, flex:1적용함.
그리고 이상하게 스크롤 바 생기는 부분 없앰

### globalTheme
스크롤 스타일 적용.(트랙 배경 안보이게 적용)